### PR TITLE
Monkey patch the cfoundry gem token parsing method

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,22 @@ require 'moneta'
 require 'time'
 require 'rufus-scheduler'
 
+CFoundry::AuthToken.class_eval do
+  def token_data
+    return @token_data if @token_data
+    return {} unless @auth_header
+
+    token = @auth_header.split(" ", 2).last
+    payload_segment = token.split(".", 3)[1]
+    data_json = Base64.decode64(payload_segment)
+    return {} unless data_json
+
+    @token_data = MultiJson.load data_json, :symbolize_keys => true
+  rescue MultiJson::DecodeError
+    {}
+  end
+end
+
 @cf_api = ENV['CF_API']
 @cf_user = ENV['CF_USER']
 @cf_password = ENV['CF_PASSWORD']


### PR DESCRIPTION
Due to the way that UAA encrypts the JWT token signature, the default method for parsing the token payload is broken (uses `subl` and regex: https://github.com/cloudfoundry-attic/cfoundry/blob/master/lib/cfoundry/auth_token.rb#L42) 

Unfortunately, since this gem is in `cloudfoundry-attic`, it's mostly abandonware at this point. So, monkeypatching is the best solution for now. This will help fix https://cloudgov.statuspage.io/incidents/6d8r343lbtbb and 18F/cg-deck#417, by getting events parsed from the firehose again.
